### PR TITLE
tune/jellyseerr: Decrease CPU and increase memory

### DIFF
--- a/apps/seerr/helmrelease.yaml
+++ b/apps/seerr/helmrelease.yaml
@@ -37,12 +37,11 @@ spec:
               LOG_LEVEL: "info"
             resources:
               requests:
-                cpu: "75m"
-                memory: "192Mi"
+                cpu: "56m"
+                memory: "240Mi"
               limits:
-                cpu: "500m"
-                memory: "768Mi"
-
+                cpu: "375m"
+                memory: "774Mi"
     service:
       main:
         ports:

--- a/docs/resource-advisor/apply-plan.json
+++ b/docs/resource-advisor/apply-plan.json
@@ -1,0 +1,248 @@
+{
+  "budgets": {
+    "cpu_m": 5940.0,
+    "memory_mi": 25039.3
+  },
+  "constraints": {
+    "max_apply_changes_per_run": 5,
+    "max_request_percent_cpu": 60.0,
+    "max_request_percent_memory": 65.0,
+    "min_data_days_for_downsize": 14.0,
+    "min_data_days_for_upsize": 14.0
+  },
+  "current_requests": {
+    "cpu_m": 3205.0,
+    "memory_mi": 10320.0
+  },
+  "generated_at": "2026-02-16T10:23:07Z",
+  "metrics_coverage_days_estimate": 1.78,
+  "metrics_window": "14d",
+  "projected_requests_after_selected": {
+    "cpu_m": 3186.0,
+    "memory_mi": 10368.0
+  },
+  "selected": [
+    {
+      "container": "main",
+      "current": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "768Mi"
+        },
+        "requests": {
+          "cpu": "75m",
+          "memory": "192Mi"
+        }
+      },
+      "delta": {
+        "requests_cpu_m": -19.0,
+        "requests_memory_mi": 48.0
+      },
+      "namespace": "default",
+      "notes": [
+        "restart_guard"
+      ],
+      "path": "apps/seerr/helmrelease.yaml",
+      "priority": [
+        1,
+        4.67,
+        49.9
+      ],
+      "recommended": {
+        "limits": {
+          "cpu": "375m",
+          "memory": "774Mi"
+        },
+        "requests": {
+          "cpu": "56m",
+          "memory": "240Mi"
+        }
+      },
+      "release": "jellyseerr",
+      "selection_reason": "upsize_within_budget",
+      "workload": "jellyseerr"
+    }
+  ],
+  "skipped": [
+    {
+      "container": "kube-state-metrics",
+      "reason": "not_allowlisted",
+      "release": "kube-prometheus-stack"
+    },
+    {
+      "container": "config-reloader",
+      "reason": "not_allowlisted",
+      "release": "kube-prometheus-stack-prometheus"
+    },
+    {
+      "container": "prometheus",
+      "reason": "not_allowlisted",
+      "release": "kube-prometheus-stack-prometheus"
+    },
+    {
+      "container": "grafana-sc-dashboard",
+      "reason": "not_allowlisted",
+      "release": "kube-prometheus-stack"
+    },
+    {
+      "container": "grafana-sc-datasources",
+      "reason": "not_allowlisted",
+      "release": "kube-prometheus-stack"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_upsize",
+      "release": "bazarr"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_upsize",
+      "release": "calibre"
+    },
+    {
+      "container": "homepage",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_upsize",
+      "release": "homepage"
+    },
+    {
+      "container": "main",
+      "reason": "not_allowlisted",
+      "release": "immich"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_upsize",
+      "release": "jellyfin"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_upsize",
+      "release": "prowlarr"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_upsize",
+      "release": "radarr"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_upsize",
+      "release": "sabnzbd"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_upsize",
+      "release": "sonarr"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_upsize",
+      "release": "uptime-kuma"
+    },
+    {
+      "container": "kube-prometheus-stack",
+      "reason": "not_allowlisted",
+      "release": "kube-prometheus-stack"
+    },
+    {
+      "container": "grafana",
+      "reason": "not_allowlisted",
+      "release": "kube-prometheus-stack"
+    },
+    {
+      "container": "actualbudget",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_downsize",
+      "release": "actualbudget"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_downsize",
+      "release": "audiobookshelf"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_downsize",
+      "release": "calibre-web-automated"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_downsize",
+      "release": "flaresolverr"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_downsize",
+      "release": "glance"
+    },
+    {
+      "container": "db",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_downsize",
+      "release": "jellystat"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_downsize",
+      "release": "jellystat"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_downsize",
+      "release": "notifiarr"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_downsize",
+      "release": "transmission"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_downsize",
+      "release": "tunarr"
+    },
+    {
+      "container": "main",
+      "coverage_days": 1.78,
+      "min_days": 14.0,
+      "reason": "insufficient_data_for_downsize",
+      "release": "vaultwarden"
+    }
+  ]
+}

--- a/docs/resource-advisor/apply-plan.md
+++ b/docs/resource-advisor/apply-plan.md
@@ -1,0 +1,29 @@
+# Resource Advisor Apply Plan
+
+- Generated at: `2026-02-16T10:23:07Z`
+- Metrics window: `14d`
+- Coverage estimate: `1.78` days
+- Selected changes: **1**
+- Skipped candidates: **28**
+
+## Node Constraint Gates
+
+- CPU budget (`requests`): `5940.0m`
+- Memory budget (`requests`): `25039.3Mi`
+- Current CPU requests: `3205.0m`
+- Current Memory requests: `10320.0Mi`
+- Projected CPU requests: `3186.0m`
+- Projected Memory requests: `10368.0Mi`
+
+## Selected Changes
+
+| Release | Container | CPU req | CPU new | Mem req | Mem new | Reason |
+|---|---|---:|---:|---:|---:|---|
+| jellyseerr | main | 75m | 56m | 192Mi | 240Mi | upsize_within_budget |
+
+## Skipped Candidates
+
+- `insufficient_data_for_downsize`: 11
+- `insufficient_data_for_upsize`: 9
+- `not_allowlisted`: 8
+

--- a/docs/resource-advisor/latest.json
+++ b/docs/resource-advisor/latest.json
@@ -1,0 +1,1161 @@
+{
+  "budget": {
+    "allocatable": {
+      "cpu": "9900m",
+      "memory": "38522Mi"
+    },
+    "current_requests_percent_of_allocatable": {
+      "cpu": 32.4,
+      "memory": 26.8
+    },
+    "recommended_requests_percent_of_allocatable": {
+      "cpu": 29.4,
+      "memory": 27.9
+    }
+  },
+  "generated_at": "2026-02-16T10:23:07Z",
+  "metrics_coverage_days_estimate": 1.78,
+  "metrics_window": "14d",
+  "mode": "apply-pr",
+  "recommendations": [
+    {
+      "action": "upsize",
+      "container": "kube-state-metrics",
+      "cpu_p95_m": 2.8,
+      "current": {
+        "limits": {
+          "cpu": "50m",
+          "memory": "128Mi"
+        },
+        "requests": {
+          "cpu": "10m",
+          "memory": "64Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": 0.0,
+        "limits_memory": 21.0,
+        "requests_cpu": 25.0,
+        "requests_memory": 25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 79.4,
+      "namespace": "monitoring",
+      "notes": [
+        "restart_guard",
+        "downscale_excluded"
+      ],
+      "recommended": {
+        "limits": {
+          "cpu": "50m",
+          "memory": "155Mi"
+        },
+        "requests": {
+          "cpu": "12m",
+          "memory": "80Mi"
+        }
+      },
+      "release": "kube-prometheus-stack",
+      "restarts_window": 19.01,
+      "workload": "kube-prometheus-stack-kube-state-metrics"
+    },
+    {
+      "action": "upsize",
+      "container": "config-reloader",
+      "cpu_p95_m": 0.4,
+      "current": {
+        "limits": {
+          "cpu": "0m",
+          "memory": "0Mi"
+        },
+        "requests": {
+          "cpu": "0m",
+          "memory": "0Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": 100.0,
+        "limits_memory": 100.0,
+        "requests_cpu": 100.0,
+        "requests_memory": 100.0
+      },
+      "kind": "statefulset",
+      "mem_p95_mi": 14.4,
+      "namespace": "monitoring",
+      "notes": [
+        "restart_guard"
+      ],
+      "recommended": {
+        "limits": {
+          "cpu": "50m",
+          "memory": "96Mi"
+        },
+        "requests": {
+          "cpu": "25m",
+          "memory": "64Mi"
+        }
+      },
+      "release": "kube-prometheus-stack-prometheus",
+      "restarts_window": 7.0,
+      "workload": "prometheus-kube-prometheus-stack-prometheus"
+    },
+    {
+      "action": "upsize",
+      "container": "prometheus",
+      "cpu_p95_m": 60.3,
+      "current": {
+        "limits": {
+          "cpu": "200m",
+          "memory": "800Mi"
+        },
+        "requests": {
+          "cpu": "50m",
+          "memory": "400Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -21.6,
+        "limits_memory": 0.0,
+        "requests_cpu": 25.0,
+        "requests_memory": 25.0
+      },
+      "kind": "statefulset",
+      "mem_p95_mi": 404.5,
+      "namespace": "monitoring",
+      "notes": [
+        "restart_guard"
+      ],
+      "recommended": {
+        "limits": {
+          "cpu": "157m",
+          "memory": "800Mi"
+        },
+        "requests": {
+          "cpu": "62m",
+          "memory": "500Mi"
+        }
+      },
+      "release": "kube-prometheus-stack-prometheus",
+      "restarts_window": 7.0,
+      "workload": "prometheus-kube-prometheus-stack-prometheus"
+    },
+    {
+      "action": "upsize",
+      "container": "main",
+      "cpu_p95_m": 13.4,
+      "current": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "768Mi"
+        },
+        "requests": {
+          "cpu": "75m",
+          "memory": "192Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": 0.8,
+        "requests_cpu": -25.0,
+        "requests_memory": 25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 396.9,
+      "namespace": "default",
+      "notes": [
+        "restart_guard"
+      ],
+      "recommended": {
+        "limits": {
+          "cpu": "375m",
+          "memory": "774Mi"
+        },
+        "requests": {
+          "cpu": "56m",
+          "memory": "240Mi"
+        }
+      },
+      "release": "jellyseerr",
+      "restarts_window": 4.67,
+      "workload": "jellyseerr"
+    },
+    {
+      "action": "upsize",
+      "container": "grafana-sc-dashboard",
+      "cpu_p95_m": 20.4,
+      "current": {
+        "limits": {
+          "cpu": "0m",
+          "memory": "0Mi"
+        },
+        "requests": {
+          "cpu": "0m",
+          "memory": "0Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": 100.0,
+        "limits_memory": 100.0,
+        "requests_cpu": 100.0,
+        "requests_memory": 100.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 73.7,
+      "namespace": "monitoring",
+      "notes": [
+        "restart_guard",
+        "downscale_excluded"
+      ],
+      "recommended": {
+        "limits": {
+          "cpu": "53m",
+          "memory": "144Mi"
+        },
+        "requests": {
+          "cpu": "27m",
+          "memory": "96Mi"
+        }
+      },
+      "release": "kube-prometheus-stack",
+      "restarts_window": 4.0,
+      "workload": "kube-prometheus-stack-grafana"
+    },
+    {
+      "action": "upsize",
+      "container": "grafana-sc-datasources",
+      "cpu_p95_m": 24.8,
+      "current": {
+        "limits": {
+          "cpu": "0m",
+          "memory": "0Mi"
+        },
+        "requests": {
+          "cpu": "0m",
+          "memory": "0Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": 100.0,
+        "limits_memory": 100.0,
+        "requests_cpu": 100.0,
+        "requests_memory": 100.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 72.4,
+      "namespace": "monitoring",
+      "notes": [
+        "restart_guard",
+        "downscale_excluded"
+      ],
+      "recommended": {
+        "limits": {
+          "cpu": "64m",
+          "memory": "141Mi"
+        },
+        "requests": {
+          "cpu": "32m",
+          "memory": "94Mi"
+        }
+      },
+      "release": "kube-prometheus-stack",
+      "restarts_window": 4.0,
+      "workload": "kube-prometheus-stack-grafana"
+    },
+    {
+      "action": "upsize",
+      "container": "main",
+      "cpu_p95_m": 28.4,
+      "current": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "1024Mi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": 25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 248.0,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "375m",
+          "memory": "768Mi"
+        },
+        "requests": {
+          "cpu": "75m",
+          "memory": "320Mi"
+        }
+      },
+      "release": "bazarr",
+      "restarts_window": 0.0,
+      "workload": "bazarr"
+    },
+    {
+      "action": "upsize",
+      "container": "main",
+      "cpu_p95_m": 35.7,
+      "current": {
+        "limits": {
+          "cpu": "1000m",
+          "memory": "3072Mi"
+        },
+        "requests": {
+          "cpu": "150m",
+          "memory": "512Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": 25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 752.8,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "750m",
+          "memory": "2304Mi"
+        },
+        "requests": {
+          "cpu": "112m",
+          "memory": "640Mi"
+        }
+      },
+      "release": "calibre",
+      "restarts_window": 0.0,
+      "workload": "calibre"
+    },
+    {
+      "action": "upsize",
+      "container": "homepage",
+      "cpu_p95_m": 21.3,
+      "current": {
+        "limits": {
+          "cpu": "300m",
+          "memory": "256Mi"
+        },
+        "requests": {
+          "cpu": "50m",
+          "memory": "128Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -7.8,
+        "requests_cpu": -25.0,
+        "requests_memory": 23.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 121.1,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "225m",
+          "memory": "236Mi"
+        },
+        "requests": {
+          "cpu": "38m",
+          "memory": "157Mi"
+        }
+      },
+      "release": "homepage",
+      "restarts_window": 0.0,
+      "workload": "homepage"
+    },
+    {
+      "action": "upsize",
+      "container": "main",
+      "cpu_p95_m": 4.9,
+      "current": {
+        "limits": {
+          "cpu": "1000m",
+          "memory": "2048Mi"
+        },
+        "requests": {
+          "cpu": "200m",
+          "memory": "768Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": 0.0,
+        "limits_memory": 0.0,
+        "requests_cpu": 0.0,
+        "requests_memory": 25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 798.4,
+      "namespace": "default",
+      "notes": [
+        "downscale_excluded"
+      ],
+      "recommended": {
+        "limits": {
+          "cpu": "1000m",
+          "memory": "2048Mi"
+        },
+        "requests": {
+          "cpu": "200m",
+          "memory": "960Mi"
+        }
+      },
+      "release": "immich",
+      "restarts_window": 0.0,
+      "workload": "immich-server"
+    },
+    {
+      "action": "upsize",
+      "container": "main",
+      "cpu_p95_m": 83.6,
+      "current": {
+        "limits": {
+          "cpu": "2500m",
+          "memory": "4096Mi"
+        },
+        "requests": {
+          "cpu": "400m",
+          "memory": "1024Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": 0.0,
+        "limits_memory": 0.0,
+        "requests_cpu": 0.0,
+        "requests_memory": 25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 1358.5,
+      "namespace": "default",
+      "notes": [
+        "downscale_excluded"
+      ],
+      "recommended": {
+        "limits": {
+          "cpu": "2500m",
+          "memory": "4096Mi"
+        },
+        "requests": {
+          "cpu": "400m",
+          "memory": "1280Mi"
+        }
+      },
+      "release": "jellyfin",
+      "restarts_window": 0.0,
+      "workload": "jellyfin"
+    },
+    {
+      "action": "upsize",
+      "container": "main",
+      "cpu_p95_m": 1.4,
+      "current": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "1024Mi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": 8.2
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 213.0,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "375m",
+          "memory": "768Mi"
+        },
+        "requests": {
+          "cpu": "75m",
+          "memory": "277Mi"
+        }
+      },
+      "release": "prowlarr",
+      "restarts_window": 0.0,
+      "workload": "prowlarr"
+    },
+    {
+      "action": "upsize",
+      "container": "main",
+      "cpu_p95_m": 5.6,
+      "current": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "1024Mi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": 24.2
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 244.6,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "375m",
+          "memory": "768Mi"
+        },
+        "requests": {
+          "cpu": "75m",
+          "memory": "318Mi"
+        }
+      },
+      "release": "radarr",
+      "restarts_window": 0.0,
+      "workload": "radarr"
+    },
+    {
+      "action": "upsize",
+      "container": "main",
+      "cpu_p95_m": 150.1,
+      "current": {
+        "limits": {
+          "cpu": "1500m",
+          "memory": "2048Mi"
+        },
+        "requests": {
+          "cpu": "150m",
+          "memory": "512Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": 25.0,
+        "requests_memory": -25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 170.5,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "1125m",
+          "memory": "1536Mi"
+        },
+        "requests": {
+          "cpu": "188m",
+          "memory": "384Mi"
+        }
+      },
+      "release": "sabnzbd",
+      "restarts_window": 0.0,
+      "workload": "sabnzbd"
+    },
+    {
+      "action": "upsize",
+      "container": "main",
+      "cpu_p95_m": 3.4,
+      "current": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "1024Mi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": 10.9
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 218.5,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "375m",
+          "memory": "768Mi"
+        },
+        "requests": {
+          "cpu": "75m",
+          "memory": "284Mi"
+        }
+      },
+      "release": "sonarr",
+      "restarts_window": 0.0,
+      "workload": "sonarr"
+    },
+    {
+      "action": "upsize",
+      "container": "main",
+      "cpu_p95_m": 35.7,
+      "current": {
+        "limits": {
+          "cpu": "300m",
+          "memory": "512Mi"
+        },
+        "requests": {
+          "cpu": "50m",
+          "memory": "128Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -7.1,
+        "requests_memory": 25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 166.9,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "225m",
+          "memory": "384Mi"
+        },
+        "requests": {
+          "cpu": "46m",
+          "memory": "160Mi"
+        }
+      },
+      "release": "uptime-kuma",
+      "restarts_window": 0.0,
+      "workload": "uptime-kuma"
+    },
+    {
+      "action": "upsize",
+      "container": "kube-prometheus-stack",
+      "cpu_p95_m": 2.8,
+      "current": {
+        "limits": {
+          "cpu": "100m",
+          "memory": "128Mi"
+        },
+        "requests": {
+          "cpu": "20m",
+          "memory": "64Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": 0.0,
+        "limits_memory": 0.0,
+        "requests_cpu": 25.0,
+        "requests_memory": 0.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 26.7,
+      "namespace": "monitoring",
+      "notes": [
+        "downscale_excluded"
+      ],
+      "recommended": {
+        "limits": {
+          "cpu": "100m",
+          "memory": "128Mi"
+        },
+        "requests": {
+          "cpu": "25m",
+          "memory": "64Mi"
+        }
+      },
+      "release": "kube-prometheus-stack",
+      "restarts_window": 0.0,
+      "workload": "kube-prometheus-stack-operator"
+    },
+    {
+      "action": "no-change",
+      "container": "grafana",
+      "cpu_p95_m": 18.9,
+      "current": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "512Mi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": 0.0,
+        "limits_memory": 0.0,
+        "requests_cpu": 0.0,
+        "requests_memory": 0.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 145.3,
+      "namespace": "monitoring",
+      "notes": [
+        "restart_guard",
+        "downscale_excluded"
+      ],
+      "recommended": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "512Mi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi"
+        }
+      },
+      "release": "kube-prometheus-stack",
+      "restarts_window": 4.0,
+      "workload": "kube-prometheus-stack-grafana"
+    },
+    {
+      "action": "downsize",
+      "container": "actualbudget",
+      "cpu_p95_m": 1.1,
+      "current": {
+        "limits": {
+          "cpu": "300m",
+          "memory": "512Mi"
+        },
+        "requests": {
+          "cpu": "50m",
+          "memory": "128Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": -25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 73.5,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "225m",
+          "memory": "384Mi"
+        },
+        "requests": {
+          "cpu": "38m",
+          "memory": "96Mi"
+        }
+      },
+      "release": "actualbudget",
+      "restarts_window": 0.0,
+      "workload": "actualbudget"
+    },
+    {
+      "action": "downsize",
+      "container": "main",
+      "cpu_p95_m": 0.3,
+      "current": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "1024Mi"
+        },
+        "requests": {
+          "cpu": "75m",
+          "memory": "256Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": -25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 124.4,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "375m",
+          "memory": "768Mi"
+        },
+        "requests": {
+          "cpu": "56m",
+          "memory": "192Mi"
+        }
+      },
+      "release": "audiobookshelf",
+      "restarts_window": 0.0,
+      "workload": "audiobookshelf"
+    },
+    {
+      "action": "downsize",
+      "container": "main",
+      "cpu_p95_m": 0.7,
+      "current": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "1024Mi"
+        },
+        "requests": {
+          "cpu": "75m",
+          "memory": "256Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": -6.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 185.1,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "375m",
+          "memory": "768Mi"
+        },
+        "requests": {
+          "cpu": "56m",
+          "memory": "241Mi"
+        }
+      },
+      "release": "calibre-web-automated",
+      "restarts_window": 0.0,
+      "workload": "calibre-web-automated"
+    },
+    {
+      "action": "downsize",
+      "container": "main",
+      "cpu_p95_m": 0.1,
+      "current": {
+        "limits": {
+          "cpu": "1000m",
+          "memory": "2048Mi"
+        },
+        "requests": {
+          "cpu": "150m",
+          "memory": "512Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": -25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 272.4,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "750m",
+          "memory": "1536Mi"
+        },
+        "requests": {
+          "cpu": "112m",
+          "memory": "384Mi"
+        }
+      },
+      "release": "flaresolverr",
+      "restarts_window": 0.0,
+      "workload": "flaresolverr"
+    },
+    {
+      "action": "downsize",
+      "container": "main",
+      "cpu_p95_m": 0.1,
+      "current": {
+        "limits": {
+          "cpu": "300m",
+          "memory": "384Mi"
+        },
+        "requests": {
+          "cpu": "50m",
+          "memory": "128Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": -25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 10.9,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "225m",
+          "memory": "288Mi"
+        },
+        "requests": {
+          "cpu": "38m",
+          "memory": "96Mi"
+        }
+      },
+      "release": "glance",
+      "restarts_window": 0.0,
+      "workload": "glance"
+    },
+    {
+      "action": "downsize",
+      "container": "db",
+      "cpu_p95_m": 7.1,
+      "current": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "1024Mi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": -5.5
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 186.0,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "375m",
+          "memory": "768Mi"
+        },
+        "requests": {
+          "cpu": "75m",
+          "memory": "242Mi"
+        }
+      },
+      "release": "jellystat",
+      "restarts_window": 0.0,
+      "workload": "jellystat"
+    },
+    {
+      "action": "downsize",
+      "container": "main",
+      "cpu_p95_m": 5.0,
+      "current": {
+        "limits": {
+          "cpu": "500m",
+          "memory": "768Mi"
+        },
+        "requests": {
+          "cpu": "100m",
+          "memory": "256Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": -25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 140.1,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "375m",
+          "memory": "576Mi"
+        },
+        "requests": {
+          "cpu": "75m",
+          "memory": "192Mi"
+        }
+      },
+      "release": "jellystat",
+      "restarts_window": 0.0,
+      "workload": "jellystat"
+    },
+    {
+      "action": "downsize",
+      "container": "main",
+      "cpu_p95_m": 0.5,
+      "current": {
+        "limits": {
+          "cpu": "300m",
+          "memory": "512Mi"
+        },
+        "requests": {
+          "cpu": "50m",
+          "memory": "128Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": -25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 9.4,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "225m",
+          "memory": "384Mi"
+        },
+        "requests": {
+          "cpu": "38m",
+          "memory": "96Mi"
+        }
+      },
+      "release": "notifiarr",
+      "restarts_window": 0.0,
+      "workload": "notifiarr"
+    },
+    {
+      "action": "downsize",
+      "container": "main",
+      "cpu_p95_m": 41.4,
+      "current": {
+        "limits": {
+          "cpu": "1000m",
+          "memory": "2048Mi"
+        },
+        "requests": {
+          "cpu": "150m",
+          "memory": "512Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": -25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 44.5,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "750m",
+          "memory": "1536Mi"
+        },
+        "requests": {
+          "cpu": "112m",
+          "memory": "384Mi"
+        }
+      },
+      "release": "transmission",
+      "restarts_window": 0.0,
+      "workload": "transmission"
+    },
+    {
+      "action": "downsize",
+      "container": "main",
+      "cpu_p95_m": 0.8,
+      "current": {
+        "limits": {
+          "cpu": "1500m",
+          "memory": "2048Mi"
+        },
+        "requests": {
+          "cpu": "200m",
+          "memory": "512Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": -25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 233.7,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "1125m",
+          "memory": "1536Mi"
+        },
+        "requests": {
+          "cpu": "150m",
+          "memory": "384Mi"
+        }
+      },
+      "release": "tunarr",
+      "restarts_window": 0.0,
+      "workload": "tunarr"
+    },
+    {
+      "action": "downsize",
+      "container": "main",
+      "cpu_p95_m": 0.1,
+      "current": {
+        "limits": {
+          "cpu": "300m",
+          "memory": "512Mi"
+        },
+        "requests": {
+          "cpu": "50m",
+          "memory": "128Mi"
+        }
+      },
+      "delta_percent": {
+        "limits_cpu": -25.0,
+        "limits_memory": -25.0,
+        "requests_cpu": -25.0,
+        "requests_memory": -25.0
+      },
+      "kind": "deployment",
+      "mem_p95_mi": 16.6,
+      "namespace": "default",
+      "notes": [],
+      "recommended": {
+        "limits": {
+          "cpu": "225m",
+          "memory": "384Mi"
+        },
+        "requests": {
+          "cpu": "38m",
+          "memory": "96Mi"
+        }
+      },
+      "release": "vaultwarden",
+      "restarts_window": 0.0,
+      "workload": "vaultwarden"
+    }
+  ],
+  "summary": {
+    "containers_analyzed": 32,
+    "containers_skipped_no_metrics": 0,
+    "containers_with_metrics": 32,
+    "downsize_count": 11,
+    "no_change_count": 1,
+    "recommendation_count": 29,
+    "total_current_requests_cpu_m": 3205.0,
+    "total_current_requests_memory_mi": 10320.0,
+    "total_recommended_requests_cpu_m": 2911.5,
+    "total_recommended_requests_memory_mi": 10752.6,
+    "upsize_count": 17
+  }
+}

--- a/docs/resource-advisor/latest.md
+++ b/docs/resource-advisor/latest.md
@@ -1,0 +1,56 @@
+# Resource Advisor Report
+
+- Generated at: `2026-02-16T10:23:07Z`
+- Mode: `apply-pr`
+- Metrics window: `14d`
+- Metrics coverage estimate: `1.78` days
+- Containers analyzed: **32**
+- Containers with metrics: **32**
+- Recommendations: **29**
+
+## Cluster Budget Snapshot
+
+- Allocatable CPU: `9900m`
+- Allocatable Memory: `38522Mi`
+- Current requests as % allocatable CPU: `32.4`
+- Current requests as % allocatable Memory: `26.8`
+- Recommended requests as % allocatable CPU: `29.4`
+- Recommended requests as % allocatable Memory: `27.9`
+
+## Data Maturity Notice
+
+Prometheus coverage is below 14 days. Use extra caution for downsizing decisions until the 14-day window is fully populated.
+
+## Recommendations
+
+| Namespace | Workload | Container | CPU req | CPU rec | Mem req | Mem rec | Action | Notes |
+|---|---|---|---:|---:|---:|---:|---|---|
+| monitoring | kube-prometheus-stack-kube-state-metrics | kube-state-metrics | 10m | 12m | 64Mi | 80Mi | upsize | restart_guard,downscale_excluded |
+| monitoring | prometheus-kube-prometheus-stack-prometheus | config-reloader | 0m | 25m | 0Mi | 64Mi | upsize | restart_guard |
+| monitoring | prometheus-kube-prometheus-stack-prometheus | prometheus | 50m | 62m | 400Mi | 500Mi | upsize | restart_guard |
+| default | jellyseerr | main | 75m | 56m | 192Mi | 240Mi | upsize | restart_guard |
+| monitoring | kube-prometheus-stack-grafana | grafana-sc-dashboard | 0m | 27m | 0Mi | 96Mi | upsize | restart_guard,downscale_excluded |
+| monitoring | kube-prometheus-stack-grafana | grafana-sc-datasources | 0m | 32m | 0Mi | 94Mi | upsize | restart_guard,downscale_excluded |
+| default | bazarr | main | 100m | 75m | 256Mi | 320Mi | upsize | - |
+| default | calibre | main | 150m | 112m | 512Mi | 640Mi | upsize | - |
+| default | homepage | homepage | 50m | 38m | 128Mi | 157Mi | upsize | - |
+| default | immich-server | main | 200m | 200m | 768Mi | 960Mi | upsize | downscale_excluded |
+| default | jellyfin | main | 400m | 400m | 1024Mi | 1280Mi | upsize | downscale_excluded |
+| default | prowlarr | main | 100m | 75m | 256Mi | 277Mi | upsize | - |
+| default | radarr | main | 100m | 75m | 256Mi | 318Mi | upsize | - |
+| default | sabnzbd | main | 150m | 188m | 512Mi | 384Mi | upsize | - |
+| default | sonarr | main | 100m | 75m | 256Mi | 284Mi | upsize | - |
+| default | uptime-kuma | main | 50m | 46m | 128Mi | 160Mi | upsize | - |
+| monitoring | kube-prometheus-stack-operator | kube-prometheus-stack | 20m | 25m | 64Mi | 64Mi | upsize | downscale_excluded |
+| monitoring | kube-prometheus-stack-grafana | grafana | 100m | 100m | 256Mi | 256Mi | no-change | restart_guard,downscale_excluded |
+| default | actualbudget | actualbudget | 50m | 38m | 128Mi | 96Mi | downsize | - |
+| default | audiobookshelf | main | 75m | 56m | 256Mi | 192Mi | downsize | - |
+| default | calibre-web-automated | main | 75m | 56m | 256Mi | 241Mi | downsize | - |
+| default | flaresolverr | main | 150m | 112m | 512Mi | 384Mi | downsize | - |
+| default | glance | main | 50m | 38m | 128Mi | 96Mi | downsize | - |
+| default | jellystat | db | 100m | 75m | 256Mi | 242Mi | downsize | - |
+| default | jellystat | main | 100m | 75m | 256Mi | 192Mi | downsize | - |
+| default | notifiarr | main | 50m | 38m | 128Mi | 96Mi | downsize | - |
+| default | transmission | main | 150m | 112m | 512Mi | 384Mi | downsize | - |
+| default | tunarr | main | 200m | 150m | 512Mi | 384Mi | downsize | - |
+| default | vaultwarden | main | 50m | 38m | 128Mi | 96Mi | downsize | - |


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `1.78` days
- CPU request budget: `5940.0m`
- Memory request budget: `25039.3Mi`
- Current requests: CPU `3205.0m`, Memory `10320.0Mi`
- Projected requests after selected changes: CPU `3186.0m`, Memory `10368.0Mi`

## Selected Changes
- `jellyseerr/main`: CPU `75m` -> `56m`, Memory `192Mi` -> `240Mi`; rationale: `upsize_within_budget`; notes: `restart_guard`

## Skipped Candidates (Reason Summary)
- `insufficient_data_for_downsize`: 11
- `insufficient_data_for_upsize`: 9
- `not_allowlisted`: 8

Includes:
- latest report artifacts
- apply plan artifacts
- HelmRelease resource changes for allowlisted app-template releases only
