### PR TITLE
tune/jellyseerr: Decrease CPU and increase memory

### DIFF
--- a/apps/seerr/helmrelease.yaml
+++ b/apps/seerr/helmrelease.yaml
@@ -37,12 +37,11 @@ spec:
               LOG_LEVEL: "info"
             resources:
               requests:
-                cpu: "75m"
-                memory: "192Mi"
+                cpu: "56m"
+                memory: "240Mi"
               limits:
-                cpu: "500m"
-                memory: "768Mi"
-
+                cpu: "375m"
+                memory: "774Mi"
     service:
       main:
         ports:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `1.81` days
- CPU request budget: `5940.0m`
- Memory request budget: `25039.3Mi`
- Current requests: CPU `3205.0m`, Memory `10320.0Mi`
- Projected requests after selected changes: CPU `3186.0m`, Memory `10368.0Mi`

## Selected Changes
- `jellyseerr/main`: CPU `75m` -> `56m`, Memory `192Mi` -> `240Mi`; rationale: `upsize_within_budget`; notes: `restart_guard`

## Skipped Candidates (Reason Summary)
- `insufficient_data_for_downsize`: 11
- `insufficient_data_for_upsize`: 9
- `not_allowlisted`: 8

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
