### PR TITLE
profilarr: pin to raspberry pi node

### DIFF
--- a/apps/profilarr/helmrelease.yaml
+++ b/apps/profilarr/helmrelease.yaml
@@ -77,3 +77,6 @@ spec:
         globalMounts:
           - path: /config
 
+    pod:
+      nodeSelector:
+        kubernetes.io/hostname: talos-uua-g6r


### PR DESCRIPTION
Pin Profilarr workload to the Raspberry Pi node (talos-uua-g6r) via nodeSelector.