### PR TITLE
profilarr: fix nodeSelector placement

### DIFF
--- a/apps/profilarr/helmrelease.yaml
+++ b/apps/profilarr/helmrelease.yaml
@@ -22,6 +22,9 @@ spec:
     controllers:
       main:
         strategy: Recreate
+        pod:
+          nodeSelector:
+            kubernetes.io/hostname: talos-uua-g6r
         containers:
           main:
             image:
@@ -76,7 +79,3 @@ spec:
         accessMode: ReadWriteOnce
         globalMounts:
           - path: /config
-
-    pod:
-      nodeSelector:
-        kubernetes.io/hostname: talos-uua-g6r


### PR DESCRIPTION
app-template/common v4 uses controller-level pod options. Move nodeSelector under controllers.main.pod.nodeSelector so it takes effect.