### PR TITLE
local-path: set worker node path for talos-uua-g6r

### DIFF
--- a/infrastructure/storage/local-path-provisioner/kustomization.yaml
+++ b/infrastructure/storage/local-path-provisioner/kustomization.yaml
@@ -16,6 +16,10 @@ patches:
         {
                 "nodePathMap":[
                 {
+                        "node":"talos-uua-g6r",
+                        "paths":["/var/lib/local-path-provisioner"]
+                },
+                {
                         "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
                         "paths":["/var/mnt/local-path-provisioner"]
                 }


### PR DESCRIPTION
local-path helper pods fail on talos-uua-g6r when using /var/mnt/local-path-provisioner (read-only in kubelet hostPath context). Add nodePathMap entry for talos-uua-g6r to use /var/lib/local-path-provisioner.