### PR TITLE
rpi: pin glance, deploy adguard, pin apps to primary

### DIFF
--- a/apps/actualbudget/values.yaml
+++ b/apps/actualbudget/values.yaml
@@ -17,6 +17,9 @@ resources:
     cpu: 300m
     memory: 512Mi
 
+nodeSelector:
+  kubernetes.io/hostname: talos-7nf-osf
+
 ingress:
   enabled: true
   className: nginx

--- a/apps/adguard/helmrelease.yaml
+++ b/apps/adguard/helmrelease.yaml
@@ -1,0 +1,98 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: adguard
+  namespace: default
+spec:
+  interval: 15m
+  timeout: 10m
+  chart:
+    spec:
+      chart: app-template
+      version: "4.2.0"
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+  install: { remediation: { retries: 3 } }
+  upgrade: { remediation: { retries: 3 } }
+  values:
+    controllers:
+      main:
+        strategy: Recreate
+        pod:
+          nodeSelector:
+            kubernetes.io/hostname: talos-uua-g6r
+        containers:
+          main:
+            image:
+              repository: adguard/adguardhome
+              tag: v0.107.56
+            env:
+              TZ: "Asia/Singapore"
+            resources:
+              requests:
+                cpu: "25m"
+                memory: "128Mi"
+              limits:
+                cpu: "300m"
+                memory: "512Mi"
+
+    service:
+      main:
+        controller: main
+        type: ClusterIP
+        ports:
+          http:
+            port: 3000
+
+      dns:
+        controller: main
+        type: LoadBalancer
+        loadBalancerIP: 10.0.0.233
+        ports:
+          dns-tcp:
+            port: 53
+            protocol: TCP
+          dns-udp:
+            port: 53
+            protocol: UDP
+
+    ingress:
+      main:
+        enabled: true
+        className: nginx
+        annotations:
+          external-dns.alpha.kubernetes.io/hostname: adguard.khzaw.dev
+          nginx.ingress.kubernetes.io/ssl-redirect: "true"
+          cert-manager.io/cluster-issuer: letsencrypt-prod
+        hosts:
+          - host: adguard.khzaw.dev
+            paths:
+              - path: /
+                pathType: Prefix
+                service:
+                  identifier: main
+                  port: http
+        tls:
+          - secretName: adguard-tls
+            hosts:
+              - adguard.khzaw.dev
+
+    persistence:
+      data:
+        enabled: true
+        type: persistentVolumeClaim
+        storageClass: local-path
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        advancedMounts:
+          main:
+            main:
+              - path: /opt/adguardhome/work
+                subPath: work
+              - path: /opt/adguardhome/conf
+                subPath: conf
+

--- a/apps/adguard/kustomization.yaml
+++ b/apps/adguard/kustomization.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://www.schemastore.org/kustomization.json
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: default
+resources:
+  - helmrelease.yaml
+

--- a/apps/audiobookshelf/helmrelease.yaml
+++ b/apps/audiobookshelf/helmrelease.yaml
@@ -29,6 +29,11 @@ spec:
     keepHistory: false
 
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/apps/autobrr/helmrelease.yaml
+++ b/apps/autobrr/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         strategy: Recreate
@@ -82,4 +87,3 @@ spec:
         accessMode: ReadWriteOnce
         globalMounts:
           - path: /config
-

--- a/apps/bazarr/helmrelease.yaml
+++ b/apps/bazarr/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/apps/calibre-web-automated/helmrelease.yaml
+++ b/apps/calibre-web-automated/helmrelease.yaml
@@ -28,6 +28,11 @@ spec:
     keepHistory: false
 
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         replicas: 1

--- a/apps/calibre/values.yaml
+++ b/apps/calibre/values.yaml
@@ -1,5 +1,10 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s/helm-charts/app-template-4.2.0/charts/other/app-template/values.schema.json
 ---
+defaultPodOptionsStrategy: merge
+defaultPodOptions:
+  nodeSelector:
+    kubernetes.io/hostname: talos-7nf-osf
+
 controllers:
   main:
     replicas: 1

--- a/apps/chartsdb/helmrelease.yaml
+++ b/apps/chartsdb/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:
@@ -65,4 +70,3 @@ spec:
           - secretName: chartsdb-tls
             hosts:
               - chartsdb.khzaw.dev
-

--- a/apps/ersatztv/helmrelease.yaml
+++ b/apps/ersatztv/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         strategy: Recreate

--- a/apps/flaresolverr/helmrelease.yaml
+++ b/apps/flaresolverr/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/apps/glance/helmrelease.yaml
+++ b/apps/glance/helmrelease.yaml
@@ -20,6 +20,9 @@ spec:
   values:
     controllers:
       main:
+        pod:
+          nodeSelector:
+            kubernetes.io/hostname: talos-uua-g6r
         containers:
           main:
             image:

--- a/apps/immich/helmrelease.yaml
+++ b/apps/immich/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:
@@ -84,6 +89,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/apps/isponsorblock-tv/helmrelease.yaml
+++ b/apps/isponsorblock-tv/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         strategy: Recreate

--- a/apps/jellyfin/helmrelease.yaml
+++ b/apps/jellyfin/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         pod:

--- a/apps/jellystat/helmrelease.yaml
+++ b/apps/jellystat/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/apps/media-postgres/helmrelease.yaml
+++ b/apps/media-postgres/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         strategy: Recreate

--- a/apps/nodecast-tv/helmrelease.yaml
+++ b/apps/nodecast-tv/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         strategy: Recreate
@@ -109,4 +114,3 @@ spec:
         enabled: true
         type: hostPath
         hostPath: /dev/dri
-

--- a/apps/prowlarr/helmrelease.yaml
+++ b/apps/prowlarr/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/apps/radarr/helmrelease.yaml
+++ b/apps/radarr/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/apps/sabnzbd/helmrelease.yaml
+++ b/apps/sabnzbd/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/apps/seerr/helmrelease.yaml
+++ b/apps/seerr/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/apps/sonarr/helmrelease.yaml
+++ b/apps/sonarr/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/apps/tracerr/helmrelease.yaml
+++ b/apps/tracerr/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         strategy: Recreate

--- a/apps/transmission/helmrelease.yaml
+++ b/apps/transmission/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/apps/tunarr/helmrelease.yaml
+++ b/apps/tunarr/helmrelease.yaml
@@ -19,6 +19,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         pod:

--- a/apps/uptime-kuma/helmrelease.yaml
+++ b/apps/uptime-kuma/helmrelease.yaml
@@ -17,6 +17,11 @@ spec:
         name: bjw-s-charts
         namespace: flux-system
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         replicas: 1
@@ -51,10 +56,6 @@ spec:
         size: 1Gi
         globalMounts:
           - path: /app/data
-
-    pod:
-      nodeSelector:
-        kubernetes.io/hostname: talos-7nf-osf
 
     ingress:
       main:

--- a/apps/vaultwarden/helmrelease.yaml
+++ b/apps/vaultwarden/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
   install: { remediation: { retries: 3 } }
   upgrade: { remediation: { retries: 3 } }
   values:
+    defaultPodOptionsStrategy: merge
+    defaultPodOptions:
+      nodeSelector:
+        kubernetes.io/hostname: talos-7nf-osf
+
     controllers:
       main:
         containers:

--- a/flux/kustomization.yaml
+++ b/flux/kustomization.yaml
@@ -54,6 +54,7 @@ resources:
   - ./kustomizations/seerr.yaml
   - ./kustomizations/jellystat.yaml
   - ./kustomizations/immich.yaml
+  - ./kustomizations/adguard.yaml
   - ./kustomizations/glance.yaml
   - ./kustomizations/tracerr.yaml
   - ./kustomizations/lan-access.yaml

--- a/flux/kustomizations/adguard.yaml
+++ b/flux/kustomizations/adguard.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/kustomization-kustomize-v1.json
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: adguard
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/adguard
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  targetNamespace: default
+  timeout: 5m
+  dependsOn:
+    - name: ingress-nginx
+    - name: external-dns
+    - name: cert-manager
+    - name: metallb-config
+    - name: local-path-provisioner
+


### PR DESCRIPTION
Changes:\n- Pin Glance to RPi node (talos-uua-g6r).\n- Pin all other apps under ./apps to primary node (talos-7nf-osf) using bjw-s common v4 defaultPodOptions merge.\n- Add AdGuard Home (pinned to RPi) with DNS LoadBalancer IP 10.0.0.233 and UI Ingress adguard.khzaw.dev.\n\nNotes:\n- Uptime Kuma previously used values.pod.nodeSelector; replaced with defaultPodOptionsStrategy: merge + defaultPodOptions.nodeSelector.\n- Calibre and ActualBudget use valuesFrom ConfigMaps; pinning is done in their values.yaml.