### PR TITLE
tune/tunarr: Decrease CPU and increase memory (+4 more)

### DIFF
--- a/apps/bazarr/helmrelease.yaml
+++ b/apps/bazarr/helmrelease.yaml
@@ -36,12 +36,11 @@ spec:
               GUID: "1000"
             resources:
               requests:
-                cpu: "100m"
-                memory: "256Mi"
+                cpu: "75m"
+                memory: "320Mi"
               limits:
-                cpu: "500m"
-                memory: "1Gi"
-
+                cpu: "375m"
+                memory: "768Mi"
     service:
       main:
         ports:

--- a/apps/booklore/helmrelease.yaml
+++ b/apps/booklore/helmrelease.yaml
@@ -54,12 +54,11 @@ spec:
                     key: DATABASE_PASSWORD
             resources:
               requests:
-                cpu: "200m"
-                memory: "384Mi"
+                cpu: "150m"
+                memory: "480Mi"
               limits:
-                cpu: "1000m"
-                memory: "1536Mi"
-
+                cpu: "750m"
+                memory: "1513Mi"
     service:
       main:
         controller: main

--- a/apps/jellyfin/helmrelease.yaml
+++ b/apps/jellyfin/helmrelease.yaml
@@ -45,11 +45,10 @@ spec:
             resources:
               requests:
                 cpu: "400m"
-                memory: "1Gi"
+                memory: "1280Mi"
               limits:
                 cpu: "2500m"
-                memory: "4Gi"
-
+                memory: "4096Mi"
     service:
       main:
         ports:

--- a/apps/tunarr/helmrelease.yaml
+++ b/apps/tunarr/helmrelease.yaml
@@ -46,11 +46,11 @@ spec:
               LIBVA_DRIVERS_PATH: "/usr/local/lib/x86_64-linux-gnu/dri"
             resources:
               requests:
-                cpu: "200m"
-                memory: "512Mi"
+                cpu: "150m"
+                memory: "640Mi"
               limits:
-                cpu: "1500m"
-                memory: "2Gi"
+                cpu: "1125m"
+                memory: "2048Mi"
             probes:
               liveness:
                 spec:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `7175.0m`, Memory `17769.0Mi`
- Projected requests after selected changes: CPU `7012.0m`, Memory `18441.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after selected changes: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5920m | 5757m | 31334Mi | 20367Mi | 15097Mi | 15769Mi |
| talos-uua-g6r | 3950m | 2370m | 1255m | 1255m | 7312Mi | 4753Mi | 2672Mi | 2672Mi |

## Selected Changes
- `tunarr/main`: CPU `200m` -> `150m`, Memory `512Mi` -> `640Mi`; replicas: `1`; total delta: CPU `-50.0m`, Mem `128.0Mi`; rationale: `upsize_with_node_fit`; notes: `restart_guard`
- `jellyfin/main`: CPU `400m` -> `400m`, Memory `1024Mi` -> `1280Mi`; replicas: `1`; total delta: CPU `0.0m`, Mem `256.0Mi`; rationale: `upsize_with_node_fit`; notes: `downscale_excluded`
- `calibre/main`: CPU `150m` -> `112m`, Memory `512Mi` -> `640Mi`; replicas: `1`; total delta: CPU `-38.0m`, Mem `128.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`
- `booklore/main`: CPU `200m` -> `150m`, Memory `384Mi` -> `480Mi`; replicas: `1`; total delta: CPU `-50.0m`, Mem `96.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`
- `bazarr/main`: CPU `100m` -> `75m`, Memory `256Mi` -> `320Mi`; replicas: `1`; total delta: CPU `-25.0m`, Mem `64.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 29
- `not_allowlisted`: 14

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
