### PR TITLE
tune/booklore: Decrease CPU and increase memory

### DIFF
--- a/apps/booklore/helmrelease.yaml
+++ b/apps/booklore/helmrelease.yaml
@@ -54,12 +54,11 @@ spec:
                     key: DATABASE_PASSWORD
             resources:
               requests:
-                cpu: "200m"
-                memory: "384Mi"
+                cpu: "150m"
+                memory: "480Mi"
               limits:
-                cpu: "1000m"
-                memory: "1536Mi"
-
+                cpu: "750m"
+                memory: "1508Mi"
     service:
       main:
         controller: main


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.12` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `7250.0m`, Memory `18217.0Mi`
- Projected requests after this service change: CPU `7200.0m`, Memory `18313.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5830m | 5780m | 31334Mi | 20367Mi | 15033Mi | 15129Mi |
| talos-uua-g6r | 3950m | 2370m | 1420m | 1420m | 7312Mi | 4753Mi | 3184Mi | 3184Mi |

## Selected Changes
- `booklore/main`: CPU `200m` -> `150m`, Memory `384Mi` -> `480Mi`; replicas: `1`; total delta: CPU `-50.0m`, Mem `96.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 29
- `not_allowlisted`: 19

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
