### PR TITLE
tune/booklore: Decrease CPU and increase memory

### DIFF
--- a/apps/booklore/helmrelease.yaml
+++ b/apps/booklore/helmrelease.yaml
@@ -54,11 +54,11 @@ spec:
                     key: DATABASE_PASSWORD
             resources:
               requests:
-                cpu: "150m"
-                memory: "480Mi"
+                cpu: "112m"
+                memory: "600Mi"
               limits:
-                cpu: "750m"
-                memory: "1508Mi"
+                cpu: "562m"
+                memory: "1728Mi"
     service:
       main:
         controller: main


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.06` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `7229.0m`, Memory `19665.0Mi`
- Projected requests after this service change: CPU `7191.0m`, Memory `19785.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5719m | 5681m | 31334Mi | 20367Mi | 16129Mi | 16249Mi |
| talos-uua-g6r | 3950m | 2370m | 1510m | 1510m | 7312Mi | 4753Mi | 3536Mi | 3536Mi |

## Selected Changes
- `booklore/main`: CPU `150m` -> `112m`, Memory `480Mi` -> `600Mi`; replicas: `1`; total delta: CPU `-38.0m`, Mem `120.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 22

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
