### PR TITLE
tune/sabnzbd: Decrease CPU and increase memory

### DIFF
--- a/apps/sabnzbd/helmrelease.yaml
+++ b/apps/sabnzbd/helmrelease.yaml
@@ -37,12 +37,11 @@ spec:
               SABNZBD__HOST_WHITELIST: "sabnzbd.${BASE_DOMAIN}"
             resources:
               requests:
-                cpu: "150m"
-                memory: "512Mi"
+                cpu: "112m"
+                memory: "640Mi"
               limits:
-                cpu: "1500m"
-                memory: "2Gi"
-
+                cpu: "1125m"
+                memory: "1606Mi"
     service:
       main:
         ports:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.31` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `7075.0m`, Memory `20516.0Mi`
- Projected requests after this service change: CPU `7037.0m`, Memory `20644.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5603m | 5565m | 31334Mi | 20367Mi | 16788Mi | 16916Mi |
| talos-uua-g6r | 3950m | 2370m | 1472m | 1472m | 7312Mi | 4753Mi | 3728Mi | 3728Mi |

## Selected Changes
- `sabnzbd/main`: CPU `150m` -> `112m`, Memory `512Mi` -> `640Mi`; replicas: `1`; total delta: CPU `-38.0m`, Mem `128.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 22

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
