### PR TITLE
tune/calibre: Decrease CPU and increase memory

### DIFF
--- a/apps/calibre/helmrelease.yaml
+++ b/apps/calibre/helmrelease.yaml
@@ -49,11 +49,11 @@ spec:
               PGID: "1000"
             resources:
               requests:
-                cpu: "63m"
-                memory: "1000Mi"
+                cpu: "47m"
+                memory: "1250Mi"
               limits:
-                cpu: "422m"
-                memory: "2919Mi"
+                cpu: "316m"
+                memory: "2189Mi"
     service:
       main:
         ports:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6960.0m`, Memory `21554.0Mi`
- Projected requests after this service change: CPU `6944.0m`, Memory `21804.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5516m | 5500m | 31334Mi | 20367Mi | 17666Mi | 17916Mi |
| talos-uua-g6r | 3950m | 2370m | 1444m | 1444m | 7312Mi | 4753Mi | 3888Mi | 3888Mi |

## Selected Changes
- `calibre/main`: CPU `63m` -> `47m`, Memory `1000Mi` -> `1250Mi`; replicas: `1`; total delta: CPU `-16.0m`, Mem `250.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 20

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
