### PR TITLE
Route root domain to blog service

### DIFF
--- a/infrastructure/public-edge/helmrelease.yaml
+++ b/infrastructure/public-edge/helmrelease.yaml
@@ -89,6 +89,8 @@ spec:
           config.yaml: |
             # Static share host routes point to the in-cluster exposure-control backend.
             ingress:
+              - hostname: ${BASE_DOMAIN}
+                service: http://blog.default.svc.cluster.local:8080
               - hostname: blog.${BASE_DOMAIN}
                 service: http://blog.default.svc.cluster.local:8080
               - hostname: mmcal.${BASE_DOMAIN}


### PR DESCRIPTION
This PR updates the Cloudflare Tunnel configuration to route the root domain (khzaw.dev) to the blog service.