### PR TITLE
tune/tracerr: Decrease CPU and memory

### DIFF
--- a/apps/tracerr/helmrelease.yaml
+++ b/apps/tracerr/helmrelease.yaml
@@ -68,11 +68,11 @@ spec:
                     key: COOKIE_SECRET
             resources:
               requests:
-                cpu: "200m"
-                memory: "512Mi"
+                cpu: "150m"
+                memory: "384Mi"
               limits:
-                cpu: "800m"
-                memory: "1536Mi"
+                cpu: "600m"
+                memory: "1152Mi"
             probes:
               startup:
                 spec:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.06` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6876.0m`, Memory `25533.0Mi`
- Projected requests after this service change: CPU `6826.0m`, Memory `25405.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5412m | 5362m | 31334Mi | 20367Mi | 21581Mi | 21453Mi |
| talos-uua-g6r | 3950m | 2370m | 1464m | 1464m | 7312Mi | 4753Mi | 3952Mi | 3952Mi |

## Selected Changes
- `tracerr/main`: CPU `200m` -> `150m`, Memory `512Mi` -> `384Mi`; replicas: `1`; total delta: CPU `-50.0m`, Mem `-128.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 30
- `not_allowlisted`: 20

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
