### PR TITLE
tune/nodecast-tv: Decrease CPU and memory

### DIFF
--- a/apps/nodecast-tv/helmrelease.yaml
+++ b/apps/nodecast-tv/helmrelease.yaml
@@ -44,11 +44,11 @@ spec:
               NODE_ENV: production
             resources:
               requests:
-                cpu: "150m"
-                memory: "384Mi"
+                cpu: "112m"
+                memory: "288Mi"
               limits:
-                cpu: "1500m"
-                memory: "1536Mi"
+                cpu: "1125m"
+                memory: "1152Mi"
             probes:
               liveness:
                 spec:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.31` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `7138.0m`, Memory `25886.0Mi`
- Projected requests after this service change: CPU `7100.0m`, Memory `25790.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5756m | 5718m | 31334Mi | 20367Mi | 22126Mi | 22030Mi |
| talos-uua-g6r | 3950m | 2370m | 1382m | 1382m | 7312Mi | 4753Mi | 3760Mi | 3760Mi |

## Selected Changes
- `nodecast-tv/main`: CPU `150m` -> `112m`, Memory `384Mi` -> `288Mi`; replicas: `1`; total delta: CPU `-38.0m`, Mem `-96.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
