### PR TITLE
tune/tracerr: Decrease CPU and memory

### DIFF
--- a/apps/tracerr/helmrelease.yaml
+++ b/apps/tracerr/helmrelease.yaml
@@ -68,11 +68,11 @@ spec:
                     key: COOKIE_SECRET
             resources:
               requests:
-                cpu: "150m"
-                memory: "384Mi"
+                cpu: "112m"
+                memory: "341Mi"
               limits:
-                cpu: "600m"
-                memory: "1152Mi"
+                cpu: "450m"
+                memory: "864Mi"
             probes:
               startup:
                 spec:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.31` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `7138.0m`, Memory `25886.0Mi`
- Projected requests after this service change: CPU `7100.0m`, Memory `25843.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5756m | 5718m | 31334Mi | 20367Mi | 22126Mi | 22083Mi |
| talos-uua-g6r | 3950m | 2370m | 1382m | 1382m | 7312Mi | 4753Mi | 3760Mi | 3760Mi |

## Selected Changes
- `tracerr/main`: CPU `150m` -> `112m`, Memory `384Mi` -> `341Mi`; replicas: `1`; total delta: CPU `-38.0m`, Mem `-43.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
