### PR TITLE
tune/reactive-resume: Decrease CPU and memory

### DIFF
--- a/apps/reactive-resume/helmrelease.yaml
+++ b/apps/reactive-resume/helmrelease.yaml
@@ -125,11 +125,11 @@ spec:
                 value: "true"
             resources:
               requests:
-                cpu: "141m"
-                memory: "288Mi"
+                cpu: "106m"
+                memory: "216Mi"
               limits:
-                cpu: "562m"
-                memory: "864Mi"
+                cpu: "422m"
+                memory: "648Mi"
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6959.0m`, Memory `25395.0Mi`
- Projected requests after this service change: CPU `6924.0m`, Memory `25323.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5604m | 5604m | 31334Mi | 20367Mi | 21667Mi | 21667Mi |
| talos-uua-g6r | 3950m | 2370m | 1355m | 1320m | 7312Mi | 4753Mi | 3728Mi | 3656Mi |

## Selected Changes
- `reactive-resume/printer`: CPU `141m` -> `106m`, Memory `288Mi` -> `216Mi`; replicas: `1`; total delta: CPU `-35.0m`, Mem `-72.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
