### PR TITLE
tune/shelfmark: Decrease CPU and memory

### DIFF
--- a/apps/shelfmark/helmrelease.yaml
+++ b/apps/shelfmark/helmrelease.yaml
@@ -75,11 +75,11 @@ spec:
                   failureThreshold: 6
             resources:
               requests:
-                cpu: "112m"
-                memory: "476Mi"
+                cpu: "84m"
+                memory: "417Mi"
               limits:
-                cpu: "844m"
-                memory: "1152Mi"
+                cpu: "633m"
+                memory: "864Mi"
     service:
       main:
         controller: main


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6959.0m`, Memory `25395.0Mi`
- Projected requests after this service change: CPU `6931.0m`, Memory `25336.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5604m | 5576m | 31334Mi | 20367Mi | 21667Mi | 21608Mi |
| talos-uua-g6r | 3950m | 2370m | 1355m | 1355m | 7312Mi | 4753Mi | 3728Mi | 3728Mi |

## Selected Changes
- `shelfmark/main`: CPU `112m` -> `84m`, Memory `476Mi` -> `417Mi`; replicas: `1`; total delta: CPU `-28.0m`, Mem `-59.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
