### PR TITLE
tune/tracerr: Decrease CPU

### DIFF
--- a/apps/tracerr/helmrelease.yaml
+++ b/apps/tracerr/helmrelease.yaml
@@ -68,11 +68,11 @@ spec:
                     key: COOKIE_SECRET
             resources:
               requests:
-                cpu: "112m"
+                cpu: "84m"
                 memory: "341Mi"
               limits:
-                cpu: "450m"
-                memory: "864Mi"
+                cpu: "338m"
+                memory: "648Mi"
             probes:
               startup:
                 spec:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6959.0m`, Memory `25395.0Mi`
- Projected requests after this service change: CPU `6931.0m`, Memory `25395.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5604m | 5576m | 31334Mi | 20367Mi | 21667Mi | 21667Mi |
| talos-uua-g6r | 3950m | 2370m | 1355m | 1355m | 7312Mi | 4753Mi | 3728Mi | 3728Mi |

## Selected Changes
- `tracerr/main`: CPU `112m` -> `84m`, Memory `341Mi` -> `341Mi`; replicas: `1`; total delta: CPU `-28.0m`, Mem `0.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
