### PR TITLE
tune/booklore-mariadb: Decrease CPU and memory

### DIFF
--- a/apps/booklore-mariadb/helmrelease.yaml
+++ b/apps/booklore-mariadb/helmrelease.yaml
@@ -56,12 +56,11 @@ spec:
                     key: DATABASE_PASSWORD
             resources:
               requests:
-                cpu: "100m"
-                memory: "256Mi"
+                cpu: "75m"
+                memory: "192Mi"
               limits:
-                cpu: "600m"
-                memory: "768Mi"
-
+                cpu: "450m"
+                memory: "576Mi"
     service:
       main:
         controller: main


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6959.0m`, Memory `25395.0Mi`
- Projected requests after this service change: CPU `6934.0m`, Memory `25331.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5604m | 5579m | 31334Mi | 20367Mi | 21667Mi | 21603Mi |
| talos-uua-g6r | 3950m | 2370m | 1355m | 1355m | 7312Mi | 4753Mi | 3728Mi | 3728Mi |

## Selected Changes
- `booklore-mariadb/main`: CPU `100m` -> `75m`, Memory `256Mi` -> `192Mi`; replicas: `1`; total delta: CPU `-25.0m`, Mem `-64.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
