### PR TITLE
tune/tunarr: Decrease CPU and increase memory

### DIFF
--- a/apps/tunarr/helmrelease.yaml
+++ b/apps/tunarr/helmrelease.yaml
@@ -46,11 +46,11 @@ spec:
               LIBVA_DRIVERS_PATH: "/usr/local/lib/x86_64-linux-gnu/dri"
             resources:
               requests:
-                cpu: "84m"
-                memory: "1000Mi"
+                cpu: "63m"
+                memory: "1072Mi"
               limits:
-                cpu: "633m"
-                memory: "1791Mi"
+                cpu: "475m"
+                memory: "1607Mi"
             probes:
               liveness:
                 spec:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.06` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6571.0m`, Memory `22849.0Mi`
- Projected requests after this service change: CPU `6550.0m`, Memory `22921.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5271m | 5250m | 31334Mi | 20367Mi | 19257Mi | 19329Mi |
| talos-uua-g6r | 3950m | 2370m | 1300m | 1300m | 7312Mi | 4753Mi | 3592Mi | 3592Mi |

## Selected Changes
- `tunarr/main`: CPU `84m` -> `63m`, Memory `1000Mi` -> `1072Mi`; replicas: `1`; total delta: CPU `-21.0m`, Mem `72.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
