### PR TITLE
tune/sonarr: Decrease CPU and increase memory

### DIFF
--- a/apps/sonarr/helmrelease.yaml
+++ b/apps/sonarr/helmrelease.yaml
@@ -37,12 +37,11 @@ spec:
               PATH: "/app/sonarr/bin:/lsiopy/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             resources:
               requests:
-                memory: "256Mi"
-                cpu: "100m"
+                cpu: "75m"
+                memory: "320Mi"
               limits:
-                memory: "1Gi"
-                cpu: "500m"
-
+                cpu: "375m"
+                memory: "1070Mi"
     service:
       main:
         ports:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.06` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6571.0m`, Memory `22849.0Mi`
- Projected requests after this service change: CPU `6546.0m`, Memory `22913.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5271m | 5246m | 31334Mi | 20367Mi | 19257Mi | 19321Mi |
| talos-uua-g6r | 3950m | 2370m | 1300m | 1300m | 7312Mi | 4753Mi | 3592Mi | 3592Mi |

## Selected Changes
- `sonarr/main`: CPU `100m` -> `75m`, Memory `256Mi` -> `320Mi`; replicas: `1`; total delta: CPU `-25.0m`, Mem `64.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
