### PR TITLE
tune/booklore: Decrease CPU and increase memory

### DIFF
--- a/apps/booklore/helmrelease.yaml
+++ b/apps/booklore/helmrelease.yaml
@@ -54,11 +54,11 @@ spec:
                     key: DATABASE_PASSWORD
             resources:
               requests:
-                cpu: "47m"
-                memory: "1172Mi"
+                cpu: "35m"
+                memory: "1465Mi"
               limits:
-                cpu: "237m"
-                memory: "2191Mi"
+                cpu: "178m"
+                memory: "2285Mi"
     service:
       main:
         controller: main


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.31` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6459.0m`, Memory `23347.0Mi`
- Projected requests after this service change: CPU `6447.0m`, Memory `23640.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5159m | 5147m | 31334Mi | 20367Mi | 19755Mi | 20048Mi |
| talos-uua-g6r | 3950m | 2370m | 1300m | 1300m | 7312Mi | 4753Mi | 3592Mi | 3592Mi |

## Selected Changes
- `booklore/main`: CPU `47m` -> `35m`, Memory `1172Mi` -> `1465Mi`; replicas: `1`; total delta: CPU `-12.0m`, Mem `293.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
