### PR TITLE
tune/reactive-resume: Decrease CPU and increase memory

### DIFF
--- a/apps/reactive-resume/helmrelease.yaml
+++ b/apps/reactive-resume/helmrelease.yaml
@@ -125,11 +125,11 @@ spec:
                 value: "true"
             resources:
               requests:
-                cpu: "106m"
-                memory: "216Mi"
+                cpu: "80m"
+                memory: "270Mi"
               limits:
-                cpu: "422m"
-                memory: "648Mi"
+                cpu: "316m"
+                memory: "778Mi"
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.31` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6459.0m`, Memory `23347.0Mi`
- Projected requests after this service change: CPU `6433.0m`, Memory `23401.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5159m | 5159m | 31334Mi | 20367Mi | 19755Mi | 19755Mi |
| talos-uua-g6r | 3950m | 2370m | 1300m | 1274m | 7312Mi | 4753Mi | 3592Mi | 3646Mi |

## Selected Changes
- `reactive-resume/printer`: CPU `106m` -> `80m`, Memory `216Mi` -> `270Mi`; replicas: `1`; total delta: CPU `-26.0m`, Mem `54.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
