### PR TITLE
tune/ersatztv: Decrease CPU and increase memory

### DIFF
--- a/apps/ersatztv/helmrelease.yaml
+++ b/apps/ersatztv/helmrelease.yaml
@@ -36,11 +36,11 @@ spec:
               TZ: "${TIMEZONE}"
             resources:
               requests:
-                cpu: "56m"
-                memory: "400Mi"
+                cpu: "42m"
+                memory: "500Mi"
               limits:
-                cpu: "1125m"
-                memory: "745Mi"
+                cpu: "844m"
+                memory: "766Mi"
     service:
       main:
         controller: main


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6369.0m`, Memory `23914.0Mi`
- Projected requests after this service change: CPU `6355.0m`, Memory `24014.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5095m | 5081m | 31334Mi | 20367Mi | 20268Mi | 20368Mi |
| talos-uua-g6r | 3950m | 2370m | 1274m | 1274m | 7312Mi | 4753Mi | 3646Mi | 3646Mi |

## Selected Changes
- `ersatztv/main`: CPU `56m` -> `42m`, Memory `400Mi` -> `500Mi`; replicas: `1`; total delta: CPU `-14.0m`, Mem `100.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
