### PR TITLE
tune/jellyseerr: Decrease CPU and increase memory

### DIFF
--- a/apps/seerr/helmrelease.yaml
+++ b/apps/seerr/helmrelease.yaml
@@ -43,11 +43,11 @@ spec:
               LOG_LEVEL: "info"
             resources:
               requests:
-                cpu: "42m"
-                memory: "300Mi"
+                cpu: "32m"
+                memory: "375Mi"
               limits:
-                cpu: "281m"
-                memory: "690Mi"
+                cpu: "211m"
+                memory: "693Mi"
     service:
       main:
         ports:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6369.0m`, Memory `23914.0Mi`
- Projected requests after this service change: CPU `6359.0m`, Memory `23989.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5095m | 5085m | 31334Mi | 20367Mi | 20268Mi | 20343Mi |
| talos-uua-g6r | 3950m | 2370m | 1274m | 1274m | 7312Mi | 4753Mi | 3646Mi | 3646Mi |

## Selected Changes
- `jellyseerr/main`: CPU `42m` -> `32m`, Memory `300Mi` -> `375Mi`; replicas: `1`; total delta: CPU `-10.0m`, Mem `75.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
