### PR TITLE
tune/reactive-resume: Decrease CPU and increase memory

### DIFF
--- a/apps/reactive-resume/helmrelease.yaml
+++ b/apps/reactive-resume/helmrelease.yaml
@@ -125,10 +125,10 @@ spec:
                 value: "true"
             resources:
               requests:
-                cpu: "80m"
-                memory: "270Mi"
+                cpu: "60m"
+                memory: "338Mi"
               limits:
-                cpu: "316m"
+                cpu: "237m"
                 memory: "778Mi"
             securityContext:
               allowPrivilegeEscalation: false


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6369.0m`, Memory `23914.0Mi`
- Projected requests after this service change: CPU `6349.0m`, Memory `23982.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5095m | 5095m | 31334Mi | 20367Mi | 20268Mi | 20268Mi |
| talos-uua-g6r | 3950m | 2370m | 1274m | 1254m | 7312Mi | 4753Mi | 3646Mi | 3714Mi |

## Selected Changes
- `reactive-resume/printer`: CPU `80m` -> `60m`, Memory `270Mi` -> `338Mi`; replicas: `1`; total delta: CPU `-20.0m`, Mem `68.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 31
- `not_allowlisted`: 23

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
