### PR TITLE
tune/jellyfin: Increase memory

### DIFF
--- a/apps/jellyfin/helmrelease.yaml
+++ b/apps/jellyfin/helmrelease.yaml
@@ -45,10 +45,10 @@ spec:
             resources:
               requests:
                 cpu: "256m"
-                memory: "2Gi"
+                memory: "2560Mi"
               limits:
                 cpu: "2500m"
-                memory: "4096Mi"
+                memory: "4472Mi"
     service:
       main:
         ports:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.06` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6297.0m`, Memory `24842.0Mi`
- Projected requests after this service change: CPU `6297.0m`, Memory `25354.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5043m | 5043m | 31334Mi | 20367Mi | 21128Mi | 21640Mi |
| talos-uua-g6r | 3950m | 2370m | 1254m | 1254m | 7312Mi | 4753Mi | 3714Mi | 3714Mi |

## Selected Changes
- `jellyfin/main`: CPU `256m` -> `256m`, Memory `2048Mi` -> `2560Mi`; replicas: `1`; total delta: CPU `0.0m`, Mem `512.0Mi`; rationale: `upsize_with_node_fit`; notes: `downscale_excluded`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 29
- `not_allowlisted`: 23
- `restart_guard_blocks_downsize`: 1

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
