### PR TITLE
tune/sonarr: Decrease CPU and increase memory

### DIFF
--- a/apps/sonarr/helmrelease.yaml
+++ b/apps/sonarr/helmrelease.yaml
@@ -37,11 +37,11 @@ spec:
               PATH: "/app/sonarr/bin:/lsiopy/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             resources:
               requests:
-                cpu: "42m"
-                memory: "450Mi"
+                cpu: "32m"
+                memory: "562Mi"
               limits:
-                cpu: "211m"
-                memory: "675Mi"
+                cpu: "158m"
+                memory: "844Mi"
     service:
       main:
         ports:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.06` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6297.0m`, Memory `24842.0Mi`
- Projected requests after this service change: CPU `6287.0m`, Memory `24954.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5043m | 5033m | 31334Mi | 20367Mi | 21128Mi | 21240Mi |
| talos-uua-g6r | 3950m | 2370m | 1254m | 1254m | 7312Mi | 4753Mi | 3714Mi | 3714Mi |

## Selected Changes
- `sonarr/main`: CPU `42m` -> `32m`, Memory `450Mi` -> `562Mi`; replicas: `1`; total delta: CPU `-10.0m`, Mem `112.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 29
- `not_allowlisted`: 23
- `restart_guard_blocks_downsize`: 1

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
