### PR TITLE
tune/calibre-web-automated: Decrease CPU and increase memory

### DIFF
--- a/apps/calibre-web-automated/helmrelease.yaml
+++ b/apps/calibre-web-automated/helmrelease.yaml
@@ -48,12 +48,11 @@ spec:
               PGID: "1000"
             resources:
               requests:
-                cpu: 75m
-                memory: 256Mi
+                cpu: "56m"
+                memory: "304Mi"
               limits:
-                cpu: 500m
-                memory: 1Gi
-
+                cpu: "375m"
+                memory: "768Mi"
     service:
       main:
         ports:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.06` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6297.0m`, Memory `24842.0Mi`
- Projected requests after this service change: CPU `6278.0m`, Memory `24890.0Mi`

- Advisory pressure: CPU `True`, Memory `False`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5043m | 5024m | 31334Mi | 20367Mi | 21128Mi | 21176Mi |
| talos-uua-g6r | 3950m | 2370m | 1254m | 1254m | 7312Mi | 4753Mi | 3714Mi | 3714Mi |

## Selected Changes
- `calibre-web-automated/main`: CPU `75m` -> `56m`, Memory `256Mi` -> `304Mi`; replicas: `1`; total delta: CPU `-19.0m`, Mem `48.0Mi`; rationale: `upsize_with_node_fit`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 29
- `not_allowlisted`: 23
- `restart_guard_blocks_downsize`: 1

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
