### PR TITLE
tune/jellyseerr: Decrease CPU and memory

### DIFF
--- a/apps/seerr/helmrelease.yaml
+++ b/apps/seerr/helmrelease.yaml
@@ -46,11 +46,11 @@ spec:
               NODE_OPTIONS: "--dns-result-order=ipv4first"
             resources:
               requests:
-                cpu: "500m"
-                memory: "1Gi"
+                cpu: "375m"
+                memory: "768Mi"
               limits:
-                cpu: "4"
-                memory: "2Gi"
+                cpu: "3000m"
+                memory: "1536Mi"
             probes:
               startup:
                 enabled: true


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.31` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6711.0m`, Memory `26227.0Mi`
- Projected requests after this service change: CPU `6586.0m`, Memory `25971.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5482m | 5357m | 31334Mi | 20367Mi | 22449Mi | 22193Mi |
| talos-uua-g6r | 3950m | 2370m | 1229m | 1229m | 7312Mi | 4753Mi | 3778Mi | 3778Mi |

## Selected Changes
- `jellyseerr/main`: CPU `500m` -> `375m`, Memory `1024Mi` -> `768Mi`; replicas: `1`; total delta: CPU `-125.0m`, Mem `-256.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 28
- `not_allowlisted`: 22
- `restart_guard_blocks_downsize`: 1

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
