### PR TITLE
tune/obsidian-livesync: Decrease CPU and memory

### DIFF
--- a/apps/obsidian-livesync/helmrelease.yaml
+++ b/apps/obsidian-livesync/helmrelease.yaml
@@ -48,12 +48,11 @@ spec:
                     key: COUCHDB_PASSWORD
             resources:
               requests:
-                cpu: "100m"
-                memory: "256Mi"
+                cpu: "75m"
+                memory: "192Mi"
               limits:
-                cpu: "500m"
-                memory: "1Gi"
-
+                cpu: "375m"
+                memory: "768Mi"
     service:
       main:
         controller: main


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.31` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6711.0m`, Memory `26227.0Mi`
- Projected requests after this service change: CPU `6686.0m`, Memory `26163.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5482m | 5457m | 31334Mi | 20367Mi | 22449Mi | 22385Mi |
| talos-uua-g6r | 3950m | 2370m | 1229m | 1229m | 7312Mi | 4753Mi | 3778Mi | 3778Mi |

## Selected Changes
- `obsidian-livesync/main`: CPU `100m` -> `75m`, Memory `256Mi` -> `192Mi`; replicas: `1`; total delta: CPU `-25.0m`, Mem `-64.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 28
- `not_allowlisted`: 22
- `restart_guard_blocks_downsize`: 1

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
