### PR TITLE
tune/jellyseerr: Decrease CPU and memory

### DIFF
--- a/apps/seerr/helmrelease.yaml
+++ b/apps/seerr/helmrelease.yaml
@@ -46,11 +46,11 @@ spec:
               NODE_OPTIONS: "--dns-result-order=ipv4first"
             resources:
               requests:
-                cpu: "375m"
-                memory: "768Mi"
+                cpu: "281m"
+                memory: "576Mi"
               limits:
-                cpu: "3000m"
-                memory: "1536Mi"
+                cpu: "2250m"
+                memory: "1152Mi"
             probes:
               startup:
                 enabled: true


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6654.0m`, Memory `26043.0Mi`
- Projected requests after this service change: CPU `6560.0m`, Memory `25851.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5470m | 5376m | 31334Mi | 20367Mi | 22449Mi | 22257Mi |
| talos-uua-g6r | 3950m | 2370m | 1184m | 1184m | 7312Mi | 4753Mi | 3594Mi | 3594Mi |

## Selected Changes
- `jellyseerr/main`: CPU `375m` -> `281m`, Memory `768Mi` -> `576Mi`; replicas: `1`; total delta: CPU `-94.0m`, Mem `-192.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 30
- `not_allowlisted`: 24

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
