### PR TITLE
tune/tunarr: Decrease CPU and memory

### DIFF
--- a/apps/tunarr/helmrelease.yaml
+++ b/apps/tunarr/helmrelease.yaml
@@ -46,11 +46,11 @@ spec:
               LIBVA_DRIVERS_PATH: "/usr/local/lib/x86_64-linux-gnu/dri"
             resources:
               requests:
-                cpu: "100m"
-                memory: "2Gi"
+                cpu: "75m"
+                memory: "1536Mi"
               limits:
-                cpu: "1"
-                memory: "4Gi"
+                cpu: "750m"
+                memory: "3072Mi"
             probes:
               liveness:
                 spec:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6654.0m`, Memory `26043.0Mi`
- Projected requests after this service change: CPU `6629.0m`, Memory `25531.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5470m | 5445m | 31334Mi | 20367Mi | 22449Mi | 21937Mi |
| talos-uua-g6r | 3950m | 2370m | 1184m | 1184m | 7312Mi | 4753Mi | 3594Mi | 3594Mi |

## Selected Changes
- `tunarr/main`: CPU `100m` -> `75m`, Memory `2048Mi` -> `1536Mi`; replicas: `1`; total delta: CPU `-25.0m`, Mem `-512.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 30
- `not_allowlisted`: 24

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
