### PR TITLE
tune/sabnzbd: Decrease CPU and memory

### DIFF
--- a/apps/sabnzbd/helmrelease.yaml
+++ b/apps/sabnzbd/helmrelease.yaml
@@ -37,11 +37,11 @@ spec:
               SABNZBD__HOST_WHITELIST: "sabnzbd.${BASE_DOMAIN}"
             resources:
               requests:
-                cpu: "84m"
-                memory: "480Mi"
+                cpu: "63m"
+                memory: "360Mi"
               limits:
-                cpu: "844m"
-                memory: "1204Mi"
+                cpu: "633m"
+                memory: "903Mi"
     service:
       main:
         ports:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.56` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `6654.0m`, Memory `26043.0Mi`
- Projected requests after this service change: CPU `6633.0m`, Memory `25923.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5470m | 5449m | 31334Mi | 20367Mi | 22449Mi | 22329Mi |
| talos-uua-g6r | 3950m | 2370m | 1184m | 1184m | 7312Mi | 4753Mi | 3594Mi | 3594Mi |

## Selected Changes
- `sabnzbd/main`: CPU `84m` -> `63m`, Memory `480Mi` -> `360Mi`; replicas: `1`; total delta: CPU `-21.0m`, Mem `-120.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 30
- `not_allowlisted`: 24

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
