### PR TITLE
tune/sonarr: Decrease CPU and memory

### DIFF
--- a/apps/sonarr/helmrelease.yaml
+++ b/apps/sonarr/helmrelease.yaml
@@ -36,14 +36,12 @@ spec:
               GUID: "1000"
               PATH: "/app/sonarr/bin:/lsiopy/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             resources:
-              # Interactive searches fan out through Prowlarr and can burst well
-              # above p95 automation data; keep CPU headroom for manual search.
               requests:
-                cpu: "100m"
-                memory: "562Mi"
+                cpu: "75m"
+                memory: "537Mi"
               limits:
-                cpu: "500m"
-                memory: "844Mi"
+                cpu: "375m"
+                memory: "805Mi"
     service:
       main:
         ports:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.06` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `7426.0m`, Memory `27051.0Mi`
- Projected requests after this service change: CPU `7401.0m`, Memory `27026.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5491m | 5466m | 31334Mi | 20367Mi | 21984Mi | 21959Mi |
| talos-uua-g6r | 3950m | 2370m | 1935m | 1935m | 7312Mi | 4753Mi | 5067Mi | 5067Mi |

## Selected Changes
- `sonarr/main`: CPU `100m` -> `75m`, Memory `562Mi` -> `537Mi`; replicas: `1`; total delta: CPU `-25.0m`, Mem `-25.0Mi`; rationale: `downsize_with_mature_data`; notes: `none`

## Skipped Candidates (Reason Summary)
- `max_changes_reached`: 27
- `not_allowlisted`: 27
- `restart_guard_blocks_downsize`: 1

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
