### PR TITLE
tune/tunarr: Decrease CPU and memory

### DIFF
--- a/apps/tunarr/helmrelease.yaml
+++ b/apps/tunarr/helmrelease.yaml
@@ -46,11 +46,11 @@ spec:
               LIBVA_DRIVERS_PATH: "/usr/local/lib/x86_64-linux-gnu/dri"
             resources:
               requests:
-                cpu: "100m"
-                memory: "2Gi"
+                cpu: "75m"
+                memory: "1616Mi"
               limits:
-                cpu: "1"
-                memory: "4Gi"
+                cpu: "1000m"
+                memory: "4096Mi"
             probes:
               liveness:
                 spec:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.31` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Apply downsize floor: CPU request savings `>= 50.0m` or Memory request savings `>= 256.0Mi`
- Apply upsize floor: CPU growth `>= 25.0m` or Memory growth `>= 128.0Mi`
- Apply limit downsizes allowed: `False`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `7426.0m`, Memory `27051.0Mi`
- Projected requests after this service change: CPU `7401.0m`, Memory `26619.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5491m | 5466m | 31334Mi | 20367Mi | 21984Mi | 21552Mi |
| talos-uua-g6r | 3950m | 2370m | 1935m | 1935m | 7312Mi | 4753Mi | 5067Mi | 5067Mi |

## Selected Changes
- `tunarr/main`: CPU `100m` -> `75m`, Memory `2048Mi` -> `1616Mi`; replicas: `1`; total delta: CPU `-25.0m`, Mem `-432.0Mi`; rationale: `downsize_with_mature_data`; notes: `limit_downsize_guard`

## Skipped Candidates (Reason Summary)
- `downsize_below_apply_floor`: 10
- `not_allowlisted`: 27
- `restart_guard_blocks_downsize`: 2
- `upsize_below_apply_floor`: 11

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
