### PR TITLE
tune/jellyfin: Increase CPU and memory

### DIFF
--- a/apps/jellyfin/helmrelease.yaml
+++ b/apps/jellyfin/helmrelease.yaml
@@ -44,10 +44,10 @@ spec:
               JELLYFIN_PublishedServerUrl: "https://jellyfin.${BASE_DOMAIN}"
             resources:
               requests:
-                cpu: "256m"
-                memory: "2560Mi"
+                cpu: "320m"
+                memory: "2804Mi"
               limits:
-                cpu: "2500m"
+                cpu: "3125m"
                 memory: "4472Mi"
     service:
       main:


### PR DESCRIPTION
Automated safe resource apply proposal.

## Constraints
- Metrics window: `14d`
- Metrics coverage estimate: `14.31` days
- Deadband policy: `10.0%` or CPU delta `>= 25.0m` or Memory delta `>= 64.0Mi`
- Apply downsize floor: CPU request savings `>= 50.0m` or Memory request savings `>= 256.0Mi`
- Apply upsize floor: CPU growth `>= 25.0m` or Memory growth `>= 128.0Mi`
- Apply limit downsizes allowed: `False`
- Advisory CPU request ceiling: `5940.0m`
- Advisory memory request ceiling: `25120.2Mi`
- Current requests: CPU `7426.0m`, Memory `27051.0Mi`
- Projected requests after this service change: CPU `7490.0m`, Memory `27295.0Mi`

- Advisory pressure: CPU `True`, Memory `True`

## Node Fit Simulation
- Assumptions: Node-fit simulation is based on current pod placement (by label app.kubernetes.io/instance) and current replica counts. Hard blocking uses allocatable node capacity; soft request budgets remain advisory posture signals only.
- Hard fit ok after this service change: `True`
- Policy: hard blocking uses allocatable node capacity; advisory request ceilings are retained for operator context and planner ordering.

| Node | Alloc CPU | Advisory CPU | Current CPU | Projected CPU | Alloc Mem | Advisory Mem | Current Mem | Projected Mem |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| talos-7nf-osf | 5950m | 3570m | 5491m | 5555m | 31334Mi | 20367Mi | 21984Mi | 22228Mi |
| talos-uua-g6r | 3950m | 2370m | 1935m | 1935m | 7312Mi | 4753Mi | 5067Mi | 5067Mi |

## Selected Changes
- `jellyfin/main`: CPU `256m` -> `320m`, Memory `2560Mi` -> `2804Mi`; replicas: `1`; total delta: CPU `64.0m`, Mem `244.0Mi`; rationale: `upsize_with_node_fit_under_advisory_pressure`; notes: `downscale_excluded`

## Skipped Candidates (Reason Summary)
- `downsize_below_apply_floor`: 10
- `not_allowlisted`: 27
- `restart_guard_blocks_downsize`: 2
- `upsize_below_apply_floor`: 11

## Hard Node Capacity Blocks
- none

## Report Source
- Latest machine-readable report is in ConfigMap `monitoring/resource-advisor-latest`.
- This PR intentionally includes HelmRelease resource changes only.
